### PR TITLE
Count distinct `<Appointment_ID, Organisation_ID>`

### DIFF
--- a/analysis/distinct_values/query.sql
+++ b/analysis/distinct_values/query.sql
@@ -1,5 +1,7 @@
 SELECT
-    COUNT(DISTINCT Appointment_ID) AS num_distinct_values,
-    COUNT(Appointment_ID) AS num_values
-FROM
-    Appointment;
+    (SELECT COUNT(*) FROM (
+        SELECT DISTINCT Appointment_ID, Organisation_ID FROM Appointment) AS t -- noqa:L016,L036
+    ) AS num_distinct_values,
+    (SELECT COUNT(*) FROM (
+        SELECT Appointment_ID FROM Appointment) AS t
+    ) AS num_values

--- a/analysis/distinct_values/wrangle.py
+++ b/analysis/distinct_values/wrangle.py
@@ -15,7 +15,7 @@ def main():
     num_distinct_values = int(row["num_distinct_values"])
     num_values = int(row["num_values"])
 
-    is_appointment_id_a_pk = num_distinct_values == num_values
+    is_pk = num_distinct_values == num_values
     num_distinct_values_rounded = utils.round_to_seven(num_distinct_values)
     num_values_rounded = utils.round_to_seven(num_values)
 
@@ -23,7 +23,7 @@ def main():
         writer = csv.writer(f)
         writer.writerow(
             [
-                "is_appointment_id_a_pk",
+                "is_pk",
                 "num_distinct_values_rounded",
                 "num_values_rounded",
             ]
@@ -34,7 +34,7 @@ def main():
             return
         writer.writerow(
             [
-                is_appointment_id_a_pk,
+                is_pk,
                 num_distinct_values_rounded,
                 num_values_rounded,
             ]

--- a/analysis/reports/report.ipynb
+++ b/analysis/reports/report.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "## Distinct values\n",
     "\n",
-    "Are values in the `Appointment_ID` column unique?\n",
+    "Are `<Appointment_ID, Organisation_ID>` tuples unique?\n",
     "If they aren't, then each row might not represent an appointment."
    ]
   },


### PR DESCRIPTION
Previously, we counted distinct `<Appointment_ID>`. However, the number of distinct values didn't equal the number of values. Now, we count distinct `<Appointment_ID, Organisation_ID>`.

We update the query, being mindful to preserve the data structure. (Consequently, we need not update the dummy data file.) We also refactor the wrangle action, to ensure a variable is named appropriately. If we end up doing this again, we may wish to remove the reference to the tuple from the notebook.