### PR TITLE
Count distinct `<Appointment_ID, Patient_ID>`

### DIFF
--- a/analysis/distinct_values/query.sql
+++ b/analysis/distinct_values/query.sql
@@ -1,6 +1,6 @@
 SELECT
     (SELECT COUNT(*) FROM (
-        SELECT DISTINCT Appointment_ID, Organisation_ID FROM Appointment) AS t -- noqa:L016,L036
+        SELECT DISTINCT Appointment_ID, Patient_ID FROM Appointment) AS t -- noqa:L016,L036
     ) AS num_distinct_values,
     (SELECT COUNT(*) FROM (
         SELECT Appointment_ID FROM Appointment) AS t

--- a/analysis/reports/report.ipynb
+++ b/analysis/reports/report.ipynb
@@ -27,8 +27,14 @@
     "\n",
     "## Distinct values\n",
     "\n",
-    "Are `<Appointment_ID, Organisation_ID>` tuples unique?\n",
-    "If they aren't, then each row might not represent an appointment."
+    "Are `<Appointment_ID, Patient_ID>` tuples unique?\n",
+    "If they aren't, then each row might not represent an appointment.\n",
+    "\n",
+    "* In [`2e4a681`][1] we checked if `<Appointment_ID>` tuples were unique. They weren't.\n",
+    "* In [`bca8390`][2] we checked if `<Appointment_ID, Organisation_ID>` tuples were unique. They weren't.\n",
+    "\n",
+    "[1]: https://github.com/opensafely/appointments-short-data-report/commit/2e4a681cc7aa7b4a90455bf82e42e8777ae40eee\n",
+    "[2]: https://github.com/opensafely/appointments-short-data-report/commit/bca8390250ef3ce6013847d23e38a5611391d65e"
    ]
   },
   {


### PR DESCRIPTION
Previously, we counted distinct `<Appointment_ID, Organisation_ID>`. However, the number of distinct values didn't equal the number of values.


Co-authored-by: Lisa Hopcroft <54442530+LisaHopcroft@users.noreply.github.com>