### PR TITLE
Return dates rather than datetimes

### DIFF
--- a/analysis/date_range/dummy_data.csv
+++ b/analysis/date_range/dummy_data.csv
@@ -1,4 +1,4 @@
-column_name,max_date,min_date
+column_name,min_date,max_date
 BookedDate,1900-01-01,1900-01-01
 StartDate,1900-01-01,1900-01-01
 ArrivedDate,1900-01-01,1900-01-01

--- a/analysis/date_range/query.sql
+++ b/analysis/date_range/query.sql
@@ -1,35 +1,35 @@
 SELECT
     'BookedDate' AS column_name,
-    CAST(MAX(BookedDate) AS DATE) AS max_date,
-    CAST(MIN(BookedDate) AS DATE) AS min_date
+    CAST(MIN(BookedDate) AS DATE) AS min_date,
+    CAST(MAX(BookedDate) AS DATE) AS max_date
 FROM Appointment
 UNION ALL
 SELECT
     'StartDate' AS column_name,
-    CAST(MAX(StartDate) AS DATE) AS max_date,
-    CAST(MIN(StartDate) AS DATE) AS min_date
+    CAST(MIN(StartDate) AS DATE) AS min_date,
+    CAST(MAX(StartDate) AS DATE) AS max_date
 FROM Appointment
 UNION ALL
 SELECT
     'ArrivedDate' AS column_name,
-    CAST(MAX(ArrivedDate) AS DATE) AS max_date,
-    CAST(MIN(ArrivedDate) AS DATE) AS min_date
+    CAST(MIN(ArrivedDate) AS DATE) AS min_date,
+    CAST(MAX(ArrivedDate) AS DATE) AS max_date
 FROM Appointment
 UNION ALL
 SELECT
     'EndDate' AS column_name,
-    CAST(MAX(EndDate) AS DATE) AS max_date,
-    CAST(MIN(EndDate) AS DATE) AS min_date
+    CAST(MIN(EndDate) AS DATE) AS min_date,
+    CAST(MAX(EndDate) AS DATE) AS max_date
 FROM Appointment
 UNION ALL
 SELECT
     'FinishedDate' AS column_name,
-    CAST(MAX(FinishedDate) AS DATE) AS max_date,
-    CAST(MIN(FinishedDate) AS DATE) AS min_date
+    CAST(MIN(FinishedDate) AS DATE) AS min_date,
+    CAST(MAX(FinishedDate) AS DATE) AS max_date
 FROM Appointment
 UNION ALL
 SELECT
     'SeenDate' AS column_name,
-    CAST(MAX(SeenDate) AS DATE) AS max_date,
-    CAST(MIN(SeenDate) AS DATE) AS min_date
+    CAST(MIN(SeenDate) AS DATE) AS min_date,
+    CAST(MAX(SeenDate) AS DATE) AS max_date
 FROM Appointment

--- a/analysis/reports/report.ipynb
+++ b/analysis/reports/report.ipynb
@@ -68,8 +68,8 @@
     "pandas.read_csv(\n",
     "    OUTPUT_DIR / \"date_range\" / \"results.csv\",\n",
     "    index_col=\"column_name\",\n",
-    "    parse_dates=[\"max_date\", \"min_date\"],\n",
-    ").loc[:, [\"min_date\", \"max_date\"]]"
+    "    parse_dates=[\"min_date\", \"max_date\"],\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
To mitigate disclosure risk, we return dates rather than datetimes from the max/min query. We also take the opportunity to remove a (very) small amount of logic from the notebook.