### PR TITLE
Fix lead time histogram

### DIFF
--- a/analysis/reports/report.ipynb
+++ b/analysis/reports/report.ipynb
@@ -6,6 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from IPython import display\n",
     "from matplotlib import pyplot\n",
     "import pathlib\n",
     "import pandas"
@@ -201,10 +202,144 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pyplot.figure(figsize=(18, 6))\n",
-    "pyplot.xlabel(lead_time[\"lead_time_in_days\"].name)\n",
-    "pyplot.ylabel(lead_time[\"frequency\"].name)\n",
-    "pyplot.bar(lead_time[\"lead_time_in_days\"], lead_time[\"frequency\"])"
+    "cut_off = 500"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display.Markdown(\n",
+    "    f\"\"\"\n",
+    "We split lead time into three intervals:\n",
+    "\n",
+    "* Lower: `min(X) <= x < -{cut_off}`\n",
+    "* Middle: `-{cut_off} <= x < {cut_off}`\n",
+    "* Upper: `{cut_off} <= x <= max(X)`\n",
+    "\"\"\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lower_mask = lead_time[\"lead_time_in_days\"] < -cut_off"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "middle_mask = (-cut_off <= lead_time[\"lead_time_in_days\"]) & (\n",
+    "    lead_time[\"lead_time_in_days\"] < cut_off\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upper_mask = cut_off <= lead_time[\"lead_time_in_days\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot(lt, yscale=\"linear\", step=False, annotations=None):\n",
+    "    fig = pyplot.figure(figsize=(18, 6))\n",
+    "    ax = fig.subplots()\n",
+    "\n",
+    "    plotter = getattr(ax, \"step\") if step else getattr(ax, \"plot\")\n",
+    "    annotations = [] if annotations is None else annotations\n",
+    "\n",
+    "    ax.set_yscale(yscale)\n",
+    "    ax.set_xlabel(\"lead_time_in_days\")\n",
+    "    ax.set_ylabel(\"frequency\")\n",
+    "    ax.vlines(\n",
+    "        annotations,\n",
+    "        0,\n",
+    "        1,\n",
+    "        colors=\"grey\",\n",
+    "        linestyles=\"dotted\",\n",
+    "        transform=ax.get_xaxis_transform(),\n",
+    "    )\n",
+    "    for annotation in annotations[1:]:\n",
+    "        ax.annotate(\n",
+    "            f\"{int(annotation / 7)}w\",\n",
+    "            (annotation, 1),\n",
+    "            xytext=(0, -2),\n",
+    "            xycoords=ax.get_xaxis_transform(),\n",
+    "            textcoords=\"offset pixels\",\n",
+    "            color=\"grey\",\n",
+    "            verticalalignment=\"top\",\n",
+    "        )\n",
+    "    plotter(\"lead_time_in_days\", \"frequency\", data=lt)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lower\n",
+    "\n",
+    "Because of the size of the range and the sparsity of the data, we represent the lower interval as a table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lead_time[lower_mask]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Middle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot(\n",
+    "    lead_time[middle_mask],\n",
+    "    yscale=\"log\",\n",
+    "    annotations=[0, 7, 28, 56, 84, 182, 273, 364],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Upper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot(lead_time[upper_mask], step=True)"
    ]
   }
  ],


### PR DESCRIPTION
The previous lead time histogram appeared not to show any data. I think this was because the x and y scale ranges were large, the data were sparse, and the bars weren't configured to fill their allocated width: ultimately, Matplotlib struggled to render many, small bars.

Now, we have split lead time into three intervals, and represented each interval more appropriately given their scale ranges and sparsity.

If we create a report with dummy data, then it looks like this:

![Screenshot 2022-11-14 at 12-45-55 Screenshot](https://user-images.githubusercontent.com/477263/201663878-02650e03-b70d-4beb-a386-c5c78a208892.png)
