### PR TITLE
Fix status query

### DIFF
--- a/analysis/status/query.sql
+++ b/analysis/status/query.sql
@@ -2,5 +2,5 @@ SELECT
     Code,
     Description
 FROM DataDictionary
-WHERE 'Table' = 'Appointment'
+WHERE [Table] = 'Appointment'
 ORDER BY Code


### PR DESCRIPTION
Transact SQL uses square brackets, rather than single quotes, to escape reserved words. Consequently, this query returned zero rows, because the literal string 'Table' was not equal to the literal string 'Appointment'. Now, we escape the reserved word `Table` correctly.

As an aside, returning zero rows caused SQL Runner to fail. For more
information, see: opensafely-core/sqlrunner#47.