### PR TITLE
Disable nbconvert timeout

### DIFF
--- a/project.yaml
+++ b/project.yaml
@@ -113,6 +113,8 @@ actions:
     #   use the basic (unstyled) template for HTML reports
     # --output-dir=output/reports
     #   write HTML reports to the `output/reports` directory
+    # --ExecutePreprocessor.timeout=-1
+    #   disable the time to wait (in seconds) for output from executions
     run: >
       python:latest jupyter nbconvert
         --execute
@@ -120,6 +122,7 @@ actions:
         --to=html
         --template basic
         --output-dir=output/reports
+        --ExecutePreprocessor.timeout=-1
         analysis/reports/*.ipynb
     needs:
       - round_distinct_values


### PR DESCRIPTION
The most recent `make_html_reports` job failed because of a `TimeoutError`. #32 added four cells to *analysis/reports/report.ipynb*, so we conclude that (at least) one of these is taking longer than the default 30s to execute. We could guess at a suitable value > 30s, but it's unlikely that the cell will take prohibitively longer, so instead we disable the timeout.