### PR TITLE
Show deciles chart of proportions

### DIFF
--- a/analysis/distinct_values/generate_measure.py
+++ b/analysis/distinct_values/generate_measure.py
@@ -1,0 +1,27 @@
+import csv
+
+from .. import OUTPUT_DIR, utils
+
+
+def main():
+    measure_id = "prop_distinct_values_by_organisation_id"
+    p_in = OUTPUT_DIR / "distinct_values" / "rows.csv"
+    p_out = OUTPUT_DIR / "distinct_values" / f"measure_{measure_id}.csv"
+    with utils.open_csv(p_in) as f_in, utils.open_csv(p_out, "w") as f_out:
+        reader = csv.reader(f_in)
+        writer = csv.writer(f_out)
+
+        # header
+        next(reader)
+        writer.writerow(["Organisation_ID", "value", "date"])
+
+        for row in reader:
+            organisation_id, booked_date, num_distinct_values, num_values = row
+            num_distinct_values = int(num_distinct_values)
+            num_values = int(num_values)
+            prop_distinct_values = num_distinct_values / num_values
+            writer.writerow([organisation_id, prop_distinct_values, booked_date])
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/reports/report.ipynb
+++ b/analysis/reports/report.ipynb
@@ -53,57 +53,14 @@
     "[5]: https://github.com/opensafely/appointments-short-data-report/commit/6922f68305e23fde2bf7adb8c1616aba62680cdf\n",
     "[6]: https://github.com/opensafely/appointments-short-data-report/commit/22bd7f2a29677fe0148e893fac9ce812e946f676\n",
     "\n",
-    "Below, we show the proportion of distinct values of `Appointment_ID` to values of `Appointment_ID`, by `BookedDate` month, by `Organisation_ID`.\n",
-    "A straight line from `<min(X), 1>` to `<max(X), 1>` would indicate that each row in the `Appointment` table represented a distinct appointment."
+    "Below, we show deciles of the proportion of distinct values of `Appointment_ID` to values of `Appointment_ID`, by `BookedDate` month, by `Organisation_ID`."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "distinct_values = pandas.read_csv(\n",
-    "    OUTPUT_DIR / \"distinct_values\" / \"results.csv\",\n",
-    "    index_col=[\"Organisation_ID\", \"booked_date\"],\n",
-    "    parse_dates=[\"booked_date\"],\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "full_date_range = pandas.date_range(\n",
-    "    distinct_values.index.get_level_values(\"booked_date\").min(),\n",
-    "    distinct_values.index.get_level_values(\"booked_date\").max(),\n",
-    "    freq=\"MS\",\n",
-    "    name=distinct_values.index.get_level_values(\"booked_date\").name,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prop_distinct_values = (\n",
-    "    (distinct_values[\"num_distinct_values\"] / distinct_values[\"num_values\"])\n",
-    "    .unstack(\"Organisation_ID\")\n",
-    "    .reindex(full_date_range)\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prop_distinct_values.plot(figsize=(18, 6), legend=False, color=\"#1f77b4\")"
+    "![](../../output/distinct_values/deciles_chart_prop_distinct_values_by_organisation_id.png)"
    ]
   },
   {

--- a/project.yaml
+++ b/project.yaml
@@ -13,16 +13,24 @@ actions:
       highly_sensitive:
         rows: output/distinct_values/rows.csv
 
-  round_distinct_values:
+  generate_prop_distinct_values_by_organisation_id_measure:
     needs: [query_distinct_values]
     run: >
-      python:latest python -m analysis.actions.round
-        --output output/distinct_values/results.csv
-        output/distinct_values/rows.csv
-        --column-names num_distinct_values num_values
+      python:latest python -m analysis.distinct_values.generate_measure
+    outputs:
+      highly_sensitive:
+        measure: output/distinct_values/measure_prop_distinct_values_by_organisation_id.csv
+
+  generate_distinct_values_deciles_charts:
+    needs: [generate_prop_distinct_values_by_organisation_id_measure]
+    run: >
+      deciles-charts:v0.0.33
+        --input-files output/distinct_values/measure_*.csv
+        --output-dir output/distinct_values
     outputs:
       moderately_sensitive:
-        results: output/distinct_values/results.csv
+        deciles_charts: output/distinct_values/deciles_chart_*.png
+        deciles_tables: output/distinct_values/deciles_table_*.csv
 
   query_status:
     run: >
@@ -125,7 +133,6 @@ actions:
         --ExecutePreprocessor.timeout=-1
         analysis/reports/*.ipynb
     needs:
-      - round_distinct_values
       - copy_date_range
       - round_num_rows_by_month
       - round_lead_time

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ exclude = '''
 branch = true
 omit = [
     ".venv/*",
+    "analysis/distinct_values/generate_measure.py",
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
We generate a measure table from the time series of counts, and a deciles chart from the measure table. Because the deciles chart doesn't show organisation-level data, we remove the `round_distinct_values` action, which rounded the time series of counts.

I've omitted *analysis/distinct_values/generate_measure.py* from the coverage report, because any tests would be low-value: the script reads and writes a file, line-by-line. Indeed, the most important line is

https://github.com/opensafely/appointments-short-data-report/blob/eee1c15f27ed6b8197b64b93ddc4584c42c0d97d/analysis/distinct_values/generate_measure.py#L22

which is where the value is calculated. (We could replace the script by refactoring the query and _project.yaml_, but that would be awkward.)