### PR TITLE
Exclude years after the current year

### DIFF
--- a/analysis/distinct_values/query.sql
+++ b/analysis/distinct_values/query.sql
@@ -18,6 +18,14 @@ FROM (
             Appointment_ID,
             DATEFROMPARTS(YEAR(BookedDate), MONTH(BookedDate), 1) AS booked_date
         FROM Appointment
+        -- There is an outlier year in BookedDate. The time between the outlier
+        -- year and the preceding year is considerable, so the interesting part
+        -- of the distribution is compressed. To avoid compressing the
+        -- interesting part of the distribution, we exclude years after the
+        -- current year from the distribution. We considered several approaches
+        -- to exclusion. For more information, see:
+        -- https://github.com/opensafely/appointments-short-data-report/pull/38
+        WHERE YEAR(BookedDate) <= (SELECT YEAR(GETDATE()))
     ) AS t0
     GROUP BY t0.Organisation_ID, t0.Appointment_ID, t0.booked_date
 ) AS t1


### PR DESCRIPTION
There is an outlier year in `BookedDate`. The time between the outlier year and the preceding year is considerable, so the interesting part of the distribution is compressed. To avoid compressing the interesting part of the distribution, we exclude years after the current year from the distribution.

@LisaHopcroft and I considered several approaches to exclusion:

* maximum year
* 99th percentile years
* hard-coded year
* years after the current year

Thresholds based on properties of the distribution (maximum, 99th percentile) are, clearly, tightly coupled to the underlying data. We know the current maximum year is implausible; but if the underlying data change, then the new maximum year may be plausible. We know the current 99th percentile is likely to include plausible years as well as implausible years; but we don't wish to exclude the plausible years. A hard-coded year could be perceived as disclosive. For these reasons, we decided to exclude years after the current year.